### PR TITLE
Convert database/main/Ag3AsS3/Hulme-e.yml to UTF8. Remove trailing tabs

### DIFF
--- a/database/main/Ag/McPeak.yml
+++ b/database/main/Ag/McPeak.yml
@@ -6,7 +6,7 @@ REFERENCES: "K. M. McPeak, S. V. Jayanti, S. J. P. Kress, S. Meyer, S. Iotti, A.
 COMMENTS: "Thermally evaporated Ag at 50 Å/s with base pressure of 3e-8 Torr, template stripped from Si wafer"
 DATA:
   - type: tabulated nk
-    data: |		
+    data: |
         0.3 1.646857286 0.972336834
         0.31 1.455629699 0.572501372
         0.32 0.920058628 0.331538655

--- a/database/main/Ag3AsS3/Hulme-e.yml
+++ b/database/main/Ag3AsS3/Hulme-e.yml
@@ -3,7 +3,7 @@
 # copyright and related rights waived via CC0 1.0
 
 REFERENCES: "K. F. Hulme et al. Synthetic proustite (Ag<sub>3</sub>AsS<sub>3</sub>): a new crystal for optical mixing, <a href=\"http://dx.doi.org/10.1063/1.1754880\"><i>Appl. Phys. Lett.</i> <b>10</b>, 133-135 (1967)</a>"
-COMMENTS: "Extraordinary ray (e), 20 °C"
+COMMENTS: "Extraordinary ray (e), 20 Â°C"
 DATA:
   - type: formula 4
     range: 0.59 4.6

--- a/database/main/Al/McPeak.yml
+++ b/database/main/Al/McPeak.yml
@@ -6,7 +6,7 @@ REFERENCES: "K. M. McPeak, S. V. Jayanti, S. J. P. Kress, S. Meyer, S. Iotti, A.
 COMMENTS: "Thermally evaporated Al at 150 Å/s, template stripped from Si wafer"
 DATA:
   - type: tabulated nk
-    data: |		
+    data: |
         0.15 0.095390828 1.283666394
         0.155 0.095510386 1.337393822
         0.16 0.09903925 1.402928641

--- a/database/main/Au/McPeak.yml
+++ b/database/main/Au/McPeak.yml
@@ -6,7 +6,7 @@ REFERENCES: "K. M. McPeak, S. V. Jayanti, S. J. P. Kress, S. Meyer, S. Iotti, A.
 COMMENTS: "Thermally evaporated Au at 10 Å/s with base pressure of 3e-8 Torr, template stripped from Si wafer"
 DATA:
   - type: tabulated nk
-    data: |		
+    data: |
         0.3 1.699838715 1.973157788
         0.31 1.746948702 1.974499878
         0.32 1.782941044 1.959795593

--- a/database/main/Cu/McPeak.yml
+++ b/database/main/Cu/McPeak.yml
@@ -6,7 +6,7 @@ REFERENCES: "K. M. McPeak, S. V. Jayanti, S. J. P. Kress, S. Meyer, S. Iotti, A.
 COMMENTS: "Thermally evaporated Cu at 35 Å/s with base pressure of 3e-8 Torr, template stripped from Si wafer"
 DATA:
   - type: tabulated nk
-    data: |		
+    data: |
         0.3 1.347459987 1.679419071
         0.31 1.321473211 1.740141215
         0.32 1.301896917 1.781554261


### PR DESCRIPTION
Hello,

Just some more very minor fixes to satisfy the Python YAML parser:
- Looks like tabs are forbidden in the YAML specs: http://www.yaml.org/faq.html
- One file had an ISO-8859-15 charset including a degree character. Here converted to proper UTF8.

Thank you!
Thibault