### PR TITLE
Fix path to the CH6H6 benzene/Moutzouris file

### DIFF
--- a/database/library.yml
+++ b/database/library.yml
@@ -5894,7 +5894,7 @@
           path: "organic/C3H6O - acetone/Rheims.yml"
         - PAGE: benzene
           name: "Benzene (C6H6)"
-          path: "organic/C6H6: benzene/Moutzouris.yml"
+          path: "organic/C6H6 - benzene/Moutzouris.yml"
         - PAGE: mercury
           name: "Mercury (Hg)"
           path: "main/Hg/Inagaki.yml"


### PR DESCRIPTION
Yet another straightforward fix to make the index coherent with the base. Looks like all files of the index are on disk in the location specified by "path".