### PR TITLE
Remove extra quote in library.yml

### DIFF
--- a/database/library.yml
+++ b/database/library.yml
@@ -2114,7 +2114,7 @@
           path: "organic/C7H8 - toluene/Kedenburg.yml"
         - PAGE: Moutzouris
           name: "Moutzouris et al. 2013: n 0.450-1.551 µm"
-          path: "organic/C7H8 - toluene/Moutzouris.yml""
+          path: "organic/C7H8 - toluene/Moutzouris.yml"
         - PAGE: Kozma
           name: "Kozma et al. 2005: n 0.3001-0.6407 µm"
           path: "organic/C7H8 - toluene/Kozma.yml"


### PR DESCRIPTION
Yet another straightforward fix for the database index.