### PR TITLE
Fixed subscript tag error in SF6

### DIFF
--- a/database/catalog-nk.yml
+++ b/database/catalog-nk.yml
@@ -1160,7 +1160,7 @@
           name: "Li 1976: n 0.15–25 µm"
           data: "main/RbF/Li.yml"
     - BOOK: SF6
-      name: "SF<sub>6</sub6> (Sulphur hexafluoride)"
+      name: "SF<sub>6</sub> (Sulphur hexafluoride)"
       info: "main/SF6.html"
       content:
         - PAGE: Vukovic


### PR DESCRIPTION
removed extraneous 6 in `</sub>` closing tag