### PR TITLE
Add comments to test/ci files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# This `dependabot.yml` file handles automatic security/version updates. In this repo,
+# it may e.g. update the version of the checkout action used in the `test.yml` action.
+# See https://github.com/dependabot/dependabot-core for additional info.
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
   # schedule:
   #     - cron: "0 13 * * 1"  # Every Monday at 9AM EST
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,8 @@
+# This `test.yml` file defines a GitHub action that will run for all pull requests,
+# and for all pushes to main. It installs the python test libraries `parameterized`
+# and `pytest`, and then runs the `pytest` command. This automatically detects
+# `test_*.py` files and executes tests therein.
+
 name: CI
 
 on:
@@ -5,8 +10,8 @@ on:
   push:
     branches:
       - main
-  schedule:
-      - cron: "0 13 * * 1"  # Every Monday at 9AM EST
+  # schedule:
+  #     - cron: "0 13 * * 1"  # Every Monday at 9AM EST
 
 jobs:
   test-parsing:

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# =========================
+# Pytest files
+# =========================
+
+tests/__pycache__

--- a/database/data-nk/main/ZnGeP2/Boyd-20-o.yml
+++ b/database/data-nk/main/ZnGeP2/Boyd-20-o.yml
@@ -2,6 +2,7 @@
 # refractiveindex.info database is in the public domain
 # copyright and related rights waived via CC0 1.0
 
+REFERENCES: |
     1) G. D. Boyd, E. Buehler, F. G Storz.
     Linear and nonlinear optical properties of ZnGeP<sub>2</sub> and CdSe.
     <a href="https://doi.org/10.1063/1.1653673"><i>Appl. Phys. Lett.</i>, <b>18</b>, 301-304 (1971)</a><br>

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,17 +1,34 @@
-"""Tests that all files can be parsed."""
+"""Tests that all files can be parsed.
+
+This test can be run by the command
+
+    pytest tests/test_parse.py
+
+or simply `pytest` from the repo directory. (The latter will automatically discover
+all test files.) This test recursively discovers all `.yml` files in the `database`
+directory and then loads them with the python `yaml` package.
+
+A test is generated individually for each `.yml` file, with the test name derived from
+the `.yml` file path. For example, the test for file `database/data/nk/main/KBr/Li.yml`
+will be `test_can_parase_database_data_nk_main_KBr_Li_yml`.
+"""
 
 import pathlib
 import unittest
 import yaml
 from parameterized import parameterized
 
+# Discover the paths for all `.yml` files.
 DATABASE_PATH = pathlib.Path(__file__).resolve().parent.parent / "database"
 PATHS = list(DATABASE_PATH.rglob("*.yml"))
 
 
 def custom_name_func(testcase_func, param_num, param):
+    # Generate the custom test name from the test arguments.
     del param_num
     path = str(param.args[0])
+    assert "/database/" in path
+    path = path[path.index("/database/") :]
     return f"{testcase_func.__name__}{parameterized.to_safe_name(path)}"
 
 


### PR DESCRIPTION
Hi @polyanskiy --- as discussed in this [thread](https://github.com/polyanskiy/refractiveindex.info-database/pull/49), I'm adding some comments to test and CI files. Here's a quick summary:

- `tests/test_parse.py`: this test discovers all `.yml` files in the database and checks that they can be successfully parsed. It can be invoked using the `pytest` command, which automatically discovers and runs tests. (The `pytest` and `parameterized` python packages must be installed).
- `.github/workflows/test.yml`: this file defines a github action which checks out the repository, installs `pytest` and `parameterized`, and then runs `pytest`. The action is configured to run on pull requests and for pushes to the master branch.

I've also added a `.github/dependabot.yml` file, which will handle automatic security/version updates. For example, when a new version of the github checkout action is available, dependabot will create a PR proposing an update to the `test.yml` file.

Finally, in creating this PR I noticed that another `.yml` file error appeared. Going forward, to make the most of the automated test/ci capabilities, I would suggest authoring PRs rather than directly pushing to the master branch. Then, you will have a chance to catch any issues before you merge.

Let me know if you have any questions or if I can help otherwise.