### PR TITLE
fix tests for windows

### DIFF
--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -27,6 +27,7 @@ def custom_name_func(testcase_func, param_num, param):
     # Generate the custom test name from the test arguments.
     del param_num
     path = str(param.args[0])
+    path = path.replace("\\", "/")  # On windows, directories are separated by `\`.
     assert "/database/" in path
     path = path[path.index("/database/") :]
     return f"{testcase_func.__name__}{parameterized.to_safe_name(path)}"


### PR DESCRIPTION
Update `test_parse.py` to handle windows-style paths, which use the `\` separator rather than `/`.