### PR TITLE
Fix duplicated content key in Tb3Ga5012 NK catalog entry

### DIFF
--- a/database/catalog-nk.yml
+++ b/database/catalog-nk.yml
@@ -2371,7 +2371,6 @@
       name: "Tb<sub>3</sub>Ga<sub>5</sub>O<sub>12</sub> (Terbium gallium garnet, TGG)"
       info: main/Tb3Ga5O12.html
       content:
-      content:
         - PAGE: Schlarb
           name: "Schlarb and Sugg 1994: n 0.405–1.18 µm"
           data: main/Tb3Ga5O12/Schlarb.yml


### PR DESCRIPTION
This error was introduced in commit 8665e6e.